### PR TITLE
Fixed default values for NewArticleTemplatesNamespaces and NewArticleTemplatesPerNamespace

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -19,11 +19,11 @@
             "description": "Enables on subpages"
         },
         "NewArticleTemplatesNamespaces": {
-            "value": [],
+            "value": null,
             "description": "Templates are used in these namespaces"
         },
         "NewArticleTemplatesPerNamespace": {
-            "value": [],
+            "value": null,
             "description": "Mapping template namespaces for page namespaces"
         },
         "NewArticleTemplatesDefault": {


### PR DESCRIPTION
See description on the [Mediawiki page of the extension](https://www.mediawiki.org/wiki/Extension_talk:NewArticleTemplates#Setting_for_namespaces_ignored_in_1.3_&_MediaWiki_1.35.4_[BUG,_SOLVED])
It is my first ever PR - I hope it is OK. :-)